### PR TITLE
Loggers instead of Print Commands

### DIFF
--- a/docs/validating_models.logger.rst
+++ b/docs/validating_models.logger.rst
@@ -1,0 +1,7 @@
+validating\_models.logger module
+================================
+
+.. automodule:: validating_models.logger
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/validating_models.rst
+++ b/docs/validating_models.rst
@@ -23,6 +23,7 @@ Submodules
    validating_models.dataset
    validating_models.drawing_utils
    validating_models.frequency_distribution_table
+   validating_models.logger
    validating_models.shacl_validation_engine
    validating_models.stats
 

--- a/generate_doc.sh
+++ b/generate_doc.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-rm -R docs/html/*
-sphinx-apidoc -f -o sphinx/ validating_models --separate
-sphinx-build sphinx/ docs/html/
+rm -Rf docs/html/*
+sphinx-apidoc -f -o docs/ validating_models --separate
+sphinx-build docs/ docs/html/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Core
 shaclapi>=0.9.0
 cairosvg>=2.5.2
-dtreeviz
+dtreeviz>=2.0.0
 matplotlib
 numpy
 openml

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import setuptools
 
-VERSION = '0.9.2'
+VERSION = '0.9.3'
 
 with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
@@ -20,7 +20,7 @@ setuptools.setup(
     install_requires=[
         'shaclapi>=0.9.0',
         'cairosvg>=2.5.2',
-        'dtreeviz',
+        'dtreeviz>=2.0.0',
         'matplotlib',
         'numpy',
         'openml',

--- a/validating_models/drawing_utils.py
+++ b/validating_models/drawing_utils.py
@@ -351,7 +351,7 @@ class GroupedStackedHistogram(Visualization):
                  data_std=None) -> None:
         self._data = data
         if isinstance(data_std, list):
-            print('std given')
+            # print('std given')
             self._data_std = data_std
         else:
             self._data_std = [np.zeros_like(self._data[0]) for i in range(len(self._data))]

--- a/validating_models/logger.py
+++ b/validating_models/logger.py
@@ -1,0 +1,18 @@
+import logging
+
+
+def get_logger(name, filename=None, level=logging.INFO, file_and_console=False):
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    if filename is not None:
+        file_handler = logging.FileHandler(filename)
+        file_handler.setLevel(level)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+    if filename is None or file_and_console:
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(level)
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
+    return logger

--- a/validating_models/models/decision_tree.py
+++ b/validating_models/models/decision_tree.py
@@ -1,6 +1,8 @@
 from dtreeviz.models.shadow_decision_tree import ShadowDecTree, ShadowDecTreeNode
 from validating_models.stats import get_decorator, get_hyperparameter_value, new_entry
+from validating_models.logger import get_logger
 
+logger = get_logger('validating_models.models.decision_tree')
 time_node_samples = get_decorator('node_samples')
 
 def get_shadow_tree_from_checker(model, checker, tree_index=None) -> ShadowDecTree:
@@ -29,15 +31,15 @@ def get_single_node_samples(node: ShadowDecTreeNode, only_calculate_single_node=
 def get_node_samples(tree: ShadowDecTree):
     result = None
     if tree.node_to_samples is not None:
-        print('Reusing Node_samples!')
+        logger.info('Reusing Node_samples!')
         result = tree.node_to_samples
     else:
         if get_hyperparameter_value('node_to_samples_non_optimized'):
-            print('Using non optimized node_samples on purpose!')
+            logger.info('Using non optimized node_samples on purpose!')
             result = tree.get_node_samples()
         else:
             try:
-                print('Calculating node samples!')
+                logger.info('Calculating node samples!')
                 dec_paths = tree.tree_model.decision_path(tree.x_data)
                 dec_paths = dec_paths.tocsc()
 

--- a/validating_models/visualizations/decision_trees.py
+++ b/validating_models/visualizations/decision_trees.py
@@ -14,6 +14,7 @@ from ..colors import VAL_COLORS, adjust_colors
 from ..groupings.general import group_by_complete_dataset
 from ..groupings.decision_trees import group_by_decision_tree_leaves, group_by_decision_tree_nodes, group_by_node_split_feature
 from .regression import get_feature_target_for_indices_plot
+from ..logger import get_logger
 from ..models.decision_tree import get_shadow_tree_from_checker, get_node_samples, get_single_node_samples
 from dtreeviz.models.shadow_decision_tree import ShadowDecTreeNode
 from ..visualizations.graphviz_helper import DTreeVizConv
@@ -23,6 +24,8 @@ import multiprocessing as mp
 from pebble import ProcessPool
 
 from validating_models.stats import get_process_stats_initalizer_args, process_stats_initializer
+
+logger = get_logger('validating_models.visualizations.ensembles')
 
 ##################################################################
 # Plots based on constraint validation counts:                   #
@@ -536,7 +539,7 @@ def dtreeviz(model,
             checker_per_prediction[y] = ConstantModelChecker(y, checker.dataset, use_gt=checker._use_gt)
             checker_per_prediction[y].validate(constraints)
 
-    print(f'Using {mp.cpu_count() if visualize_in_parallel else 1} worker(s)!')
+    logger.debug(f'Using {mp.cpu_count() if visualize_in_parallel else 1} worker(s)!')
     with ProcessPool(max_workers=mp.cpu_count(),context=mp.get_context('spawn'), initializer=process_stats_initializer, initargs=get_process_stats_initalizer_args()) as pool:
         for i, node in enumerate(tqdm(nodes_to_plot)):
             if use_node_predictions:

--- a/validating_models/visualizations/ensembles.py
+++ b/validating_models/visualizations/ensembles.py
@@ -9,6 +9,7 @@ from ..colors import adjust_colors
 from ..constraint import Constraint
 import numpy as np
 from ..groupings.classification import group_by_gt_class
+from ..logger import get_logger
 from ..models.random_forest import get_shadow_forest_from_checker
 from ..models.decision_tree import get_shadow_tree_from_checker
 from ..groupings.general import group_by_complete_dataset
@@ -18,6 +19,8 @@ from ..visualizations import graphviz_helper
 from ..visualizations import decision_trees
 from tqdm import tqdm
 from ..models.decision_tree import get_single_node_samples
+
+logger = get_logger('validating_models.visualizations.ensembles')
 
 def node_name(i):
     return f'estimator{i}'
@@ -46,7 +49,7 @@ def group_results_by_clustering(X):
                 continue
             all_labels.append(labels)
         best_idx = np.argmax(np.array(scores))
-        print("Best Silhouette Score: " + str(np.max(np.array(scores))))
+        logger.debug("Best Silhouette Score: " + str(np.max(np.array(scores))))
     else:
         return np.zeros((X.shape[0],)), 1
     return all_labels[best_idx], best_idx + 2 


### PR DESCRIPTION
This PR aims at reducing the print outs when using ``validating_models`` as a library by using loggers instead of ``print()`` commands. This way the logger level can be changed by the user to change the amount of outputs.